### PR TITLE
Create harbour-docscanner-sv.ts

### DIFF
--- a/translations/harbour-docscanner-sv.ts
+++ b/translations/harbour-docscanner-sv.ts
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <source>Created by Mikko Lepp��nen</source>
+        <translation>Skapad av Mikko Leppänen</translation>
+    </message>
+    <message>
+        <source>The source code is available at %1</source>
+        <translation>Källkoden finns tillgänglig på %1</translation>
+    </message>
+    <message>
+        <source>Doc Scanner</source>
+        <translation>Doc Scanner</translation>
+    </message>
+    <message>
+        <source>Sailfish OS</source>
+        <translation>SailfishOS</translation>
+    </message>
+</context>
+<context>
+    <name>ImagePage</name>
+    <message>
+        <source>Convert to PDF</source>
+        <translation>Konvertera till PDF</translation>
+    </message>
+    <message>
+        <source>Send Email</source>
+        <translation>Skicka e-post</translation>
+    </message>
+</context>
+<context>
+    <name>ImagesPage</name>
+    <message>
+        <source>Images</source>
+        <translation>Bilder</translation>
+    </message>
+    <message>
+        <source>Deleting image...</source>
+        <translation>Tar bort bild...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <source>Upload Image</source>
+        <translation>Ladda upp bild</translation>
+    </message>
+    <message>
+        <source>Show Scanned Images</source>
+        <translation>Visa skannade bilder</translation>
+    </message>
+</context>
+<context>
+    <name>ScannedImagesPage</name>
+    <message>
+        <source>Scanned Images</source>
+        <translation>Skannade bilder</translation>
+    </message>
+    <message>
+        <source>Deleting image...</source>
+        <translation>Tar bort bild...</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Swedish translation if wanted.
Translation strings for menu option 'Options', and for whole options page, missing in master translation file.
